### PR TITLE
List items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "ironclad"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,11 @@ pub mod tables {
         let mut scan_table_input = ScanInput::default();
         scan_table_input.table_name = table_name.to_string();
         let scan_output = client.scan(&scan_table_input).sync().expect("Scan Failed");
-        println!("There are {:?} items in {:?}\n",scan_output.count.unwrap(), scan_table_input.table_name);
+        println!(
+            "There are {:?} items in {:?}\n",
+            scan_output.count.unwrap(),
+            scan_table_input.table_name
+        );
         match scan_output.items {
             Some(vector) => {
                 let mut count = 1;
@@ -228,13 +232,14 @@ pub mod tables {
 
                     let mut versions = secrets.get("version").unwrap().clone();
                     let version = versions.n.unwrap();
-                    println!("Secret {}:\nName: {:?}\nVersion: {:?}", count,secret_name,version);
+                    println!(
+                        "Secret {}:\nName: {:?}\nVersion: {:?}",
+                        count, secret_name, version
+                    );
                     count = count + 1;
                 }
             }
-            None => {
-                ;
-            }
+            None => {}
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,12 +323,9 @@ fn main() {
         }
     } else if let Some(x) = app_matches.subcommand_matches("view") {
         if x.is_present("table") {
-            println!(
-                "I'd be attempting to list the secrets in the table specified: {:?}",
-                x.value_of("table").unwrap()
-            );
+            tables::list_items(x.value_of("table").unwrap());
         } else {
-            println!("I'd be attemtping to list the secrets in the default table.");
+            tables::list_items("ironclad-store");
         }
     } else if let Some(x) = app_matches.subcommand_matches("getall") {
         if x.is_present("table") {


### PR DESCRIPTION
Created the list_items function in lib.rs and updated the "view" subcommand in the main logic.

Some limitations to note for now (potentially to work in next Sprint): 
- We are only able to parse through secrets of a very specific form (that's okay considering our put only handles that form, but a potential thing to look out for as we scale up).
- Doesn't handle tables of different regions yet, but does list by name.
This should fix #25 